### PR TITLE
Selinux dockersock

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,5 +6,7 @@ fixtures:
       repo: git://github.com/stahnma/puppet-module-epel.git
     apt:
       repo: git://github.com/puppetlabs/puppetlabs-apt.git
+    selinux:
+      repo: git://github.com:voxpupuli/puppet-selinux.git
   symlinks:
     docker: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,6 +7,6 @@ fixtures:
     apt:
       repo: git://github.com/puppetlabs/puppetlabs-apt.git
     selinux:
-      repo: git://github.com:voxpupuli/puppet-selinux.git
+      repo: git://github.com/voxpupuli/puppet-selinux.git
   symlinks:
     docker: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ log
 Gemfile.lock
 coverage/*
 Dockerfile.override
+bin

--- a/files/dockersock.te
+++ b/files/dockersock.te
@@ -1,0 +1,12 @@
+module dockersock 1.0;
+
+require {
+        type docker_var_run_t;
+        type docker_t;
+        type svirt_lxc_net_t;
+        class sock_file write;
+        class unix_stream_socket connectto;
+}
+
+allow svirt_lxc_net_t docker_t:unix_stream_socket connectto;
+allow svirt_lxc_net_t docker_var_run_t:sock_file write;

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,22 @@
 # == Class: docker::config
 #
-class docker::config {
+# Configures users to be added to the docker group.
+#
+# Configures a selinux module to allow container access to the docker
+# daemon's unix socket.
+#
+class docker::config (
+  $selinux_dockersock_enabled = $docker::selinux_dockersock_enabled,
+){
+
   docker::system_user { $docker::docker_users: }
+
+  if $::osfamily == 'RedHat' and $selinux_dockersock_enabled {
+
+    selinux::module { 'dockersock':
+      ensure    => 'present',
+      source_te => 'puppet:///modules/docker/dockersock.te',
+      builder   => 'simple'
+    }
+  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,7 @@ class docker::config (
 
   docker::system_user { $docker::docker_users: }
 
-  if $::osfamily == 'RedHat' and $selinux_dockersock_enabled {
+  if $facts['os']['family'] == 'RedHat' and $selinux_dockersock_enabled {
 
     selinux::module { 'dockersock':
       ensure    => 'present',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -295,7 +295,7 @@ class docker(
   $log_driver                        = $docker::params::log_driver,
   $log_opt                           = $docker::params::log_opt,
   $selinux_enabled                   = $docker::params::selinux_enabled,
-  $selinux_dockersock_enabled        = $docker::params::selinux_dockersock_enabled,
+  $selinux_dockersock_enabled        = false,
   $use_upstream_package_source       = $docker::params::use_upstream_package_source,
   $pin_upstream_package_source       = $docker::params::pin_upstream_package_source,
   $apt_source_pin_level              = $docker::params::apt_source_pin_level,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,6 +151,12 @@
 #   support  the  BTRFS storage driver.
 #   Valid values: true, false
 #
+# [*selinux_dockersock_enabled*]
+#   Allow containers to access docker.sock under Fedora or RHEL with selinux enabled.
+#   Default is false.
+#   See https://github.com/dpw/selinux-dockersock for more information.
+#   Valid values: true, false
+#
 # [*use_upstream_package_source*]
 #   Whether or not to use the upstream package source.
 #   If you run your own package mirror, you may set this
@@ -289,6 +295,7 @@ class docker(
   $log_driver                        = $docker::params::log_driver,
   $log_opt                           = $docker::params::log_opt,
   $selinux_enabled                   = $docker::params::selinux_enabled,
+  $selinux_dockersock_enabled        = $docker::params::selinux_dockersock_enabled,
   $use_upstream_package_source       = $docker::params::use_upstream_package_source,
   $pin_upstream_package_source       = $docker::params::pin_upstream_package_source,
   $apt_source_pin_level              = $docker::params::apt_source_pin_level,
@@ -405,6 +412,14 @@ class docker(
 
   if $selinux_enabled {
     validate_re($selinux_enabled, '^(true|false)$', 'selinux_enabled must be true or false')
+  }
+
+  if $selinux_dockersock_enabled {
+    validate_re($selinux_dockersock_enabled, '^(true|false)$', 'selinux_dockersock must be true or false')
+
+    if(!$selinux_enabled) {
+      fail('selinux_enabled property must be set to true when selinux_dockersock_enabled is true')
+    }
   }
 
   if($tls_enable) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,7 @@ class docker::params {
   $log_driver                        = undef
   $log_opt                           = []
   $selinux_enabled                   = undef
+  $selinux_dockersock_enabled        = undef
   $socket_group                      = undef
   $labels                            = []
   $service_state                     = running

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,6 @@ class docker::params {
   $log_driver                        = undef
   $log_opt                           = []
   $selinux_enabled                   = undef
-  $selinux_dockersock_enabled        = undef
   $socket_group                      = undef
   $labels                            = []
   $service_state                     = running

--- a/metadata.json
+++ b/metadata.json
@@ -10,6 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 4.0.0"},
+    {"name":"puppet/selinux","version_requirement":">= 1.2.0 < 2.0.0"},
     {"name":"stahnma/epel","version_requirement":">= 0.0.6"}
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This PR adds the ability to enable container communication through the docker daemon's unix socket.

The most common use case for this is for a container to act as a client to the docker daemon it is running on, for things like starting sibling containers from within a container. 